### PR TITLE
Scheme for config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ exchangeExtension:
             gbp: [] # use default format 
     
     session: [FALSE] # save info about currencies to session, default is only to cookie
-    vat: [NULL] # add number like percent, example: 21
+    vat: [0] # add number like percent, example: 21
     strict: [FALSE] # default enabled, download only defined currencies, example: ['CZK', 'EUR']
     defaultFormat: [NULL] # how format currency if format is not defined, value is array like above "currencies.czk" 
     managerParameter: [currency] # is parameter for query, cookie and session if is available

--- a/src/DI/ExchangeExtension.php
+++ b/src/DI/ExchangeExtension.php
@@ -14,7 +14,7 @@ final class ExchangeExtension extends NDI\CompilerExtension
 	public function getConfigSchema(): \Nette\Schema\Schema
 	{
 		return Expect::structure([
-			'vat'              => Expect::int(),
+			'vat'              => Expect::int(0),
 			'strict'           => Expect::bool(true),
 			'defaultFormat'    => Expect::array(),
 			'currencies'       => Expect::anyOf(Expect::arrayOf('array'), false)->default([

--- a/src/DI/ExchangeExtension.php
+++ b/src/DI/ExchangeExtension.php
@@ -6,6 +6,7 @@ use h4kuna\Exchange;
 use h4kuna\Number;
 use Nette\DI as NDI;
 use Nette\Schema\Expect;
+use Nette\Utils\Validators;
 
 final class ExchangeExtension extends NDI\CompilerExtension
 {
@@ -16,7 +17,7 @@ final class ExchangeExtension extends NDI\CompilerExtension
 			'vat'              => Expect::int(),
 			'strict'           => Expect::bool(true),
 			'defaultFormat'    => Expect::array(),
-			'currencies'       => Expect::array()->default([
+			'currencies'       => Expect::anyOf(Expect::arrayOf('array'), false)->default([
 				'czk' => ['unit' => 'Kč'],
 				'eur' => ['unit' => '€', 'mask' => 'U 1'],
 				'usd' => ['unit' => '$', 'mask' => 'U1']
@@ -25,7 +26,7 @@ final class ExchangeExtension extends NDI\CompilerExtension
 				. DIRECTORY_SEPARATOR . 'currencies'),
 			'session'          => Expect::bool(false),
 			'managerParameter' => Expect::string('currency'),
-			'filters'          => Expect::array()->default([
+			'filters'          => Expect::anyOf(Expect::arrayOf('array'), false)->default([
 				'currency' => 'currency',
 				'vat'      => 'vat'
 			])

--- a/src/DI/ExchangeExtension.php
+++ b/src/DI/ExchangeExtension.php
@@ -73,7 +73,7 @@ final class ExchangeExtension extends NDI\CompilerExtension
 				->getResultDefinition()->addSetup('addFilter', [$this->config->filters['currency'], [$this->prefix('@filters'), 'format']]);
 			if ($this->config->vat) {
 				$latte->addSetup('addFilter', [
-					$this->config['filters']['vat'],
+					$this->config->filters['vat'],
 					[$this->prefix('@filters'), 'formatVat']
 				]);
 			}

--- a/src/DI/ExchangeExtension.php
+++ b/src/DI/ExchangeExtension.php
@@ -6,7 +6,6 @@ use h4kuna\Exchange;
 use h4kuna\Number;
 use Nette\DI as NDI;
 use Nette\Schema\Expect;
-use Nette\Utils\Validators;
 
 final class ExchangeExtension extends NDI\CompilerExtension
 {

--- a/src/ExchangeManager.php
+++ b/src/ExchangeManager.php
@@ -108,13 +108,13 @@ class ExchangeManager
 
 	protected function getQuery(): string
 	{
-		return $this->request->getQuery($this->parameter, '');
+		return $this->request->getQuery($this->parameter) ?? '';
 	}
 
 
 	protected function getCookie(): string
 	{
-		return $this->request->getCookie($this->parameter, '');
+		return $this->request->getCookie($this->parameter) ?? '';
 	}
 
 


### PR DESCRIPTION
Je to jen takový nástřel.
Odstraněna deprecated funkce validateConfig.
Validace configu se provádí přes getConfigSchema, zde by to chtělo asi ještě doladit.
Oprava Http\Request::getQuery() defaultní parametr je také deprecated.

